### PR TITLE
[feat] Migrate python code to typescript with test code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+coverage

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
+    "lodash.clonedeep": "^4.5.0",
     "ts-loader": "^8.1.0",
     "typescript": "^4.2.3",
     "webpack": "^5.28.0",
@@ -26,6 +27,7 @@
     "@babel/preset-env": "^7.13.12",
     "@babel/preset-typescript": "^7.13.0",
     "@types/jest": "^26.0.22",
+    "@types/lodash.clonedeep": "^4.5.6",
     "@typescript-eslint/eslint-plugin": "^4.20.0",
     "@typescript-eslint/parser": "^4.20.0",
     "babel-jest": "^26.6.3",

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,18 +1,199 @@
-import add from '../';
+import {
+  // models
+  Name,
+  // utils
+  easternToName,
+  mononymToName,
+  westernToName,
+  // constants
+  EASTERN_ORDER,
+  WESTERN_ORDER
+} from '../';
 
-describe('add 함수 테스트', () => {
-  it('3 + 5 = 8', () => {
-    const result = add(3, 5);
-    expect(result).toBe(8);
+describe('Name model test', () => {
+  it(`Should return a proper name when 'formattedName' function is called (eastern)`, () => {
+    const name = new Name({
+      name: {
+        given: '길동',
+        family: '홍'
+      },
+      order: ['family', 'given'],
+      encode: 'eastern'
+    });
+
+    expect(name.formattedName()).toBe('홍길동');
   });
 
-  it('-0 + -0 = -0', () => {
-    const result = add(-0, -0);
-    expect(result).toBe(-0);
+  it(`Should return a proper name when 'formattedName' function is called (mononym)`, () => {
+    const name = new Name({
+      name: 'Mr. Random',
+      order: [],
+      encode: 'mononym'
+    });
+
+    expect(name.formattedName()).toBe('Mr. Random');
   });
 
-  it('Number.MAX_SAFE_INTEGER + NUMBER.MAX_SAFE_INTEGER = 18014398509481982', () => {
-    const result = add(Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER);
-    expect(result).toBe(18014398509481982);
+  it(`Should return a proper name when 'formattedName' function is called (western)`, () => {
+    const name = new Name({
+      name: {
+        given: 'John',
+        middle: 'Middle',
+        family: 'Doe'
+      },
+      order: ['given', 'middle', 'family'],
+      encode: 'western'
+    });
+
+    expect(name.formattedName()).toBe('John Middle Doe');
+  });
+
+  it('Change the name order and get its source (eastern)', () => {
+    const name = new Name({
+      name: {
+        given: 'John',
+        middle: 'Middle',
+        family: 'Doe'
+      },
+      order: ['given', 'middle', 'family'],
+      encode: 'western'
+    });
+    const source = {
+      encode: 'western',
+      name: {
+        family: 'Doe',
+        given: 'John',
+        middle: 'Middle'
+      },
+      order: ['family', 'given']
+    };
+
+    name.setOrder(EASTERN_ORDER);
+    expect(name.source()).toEqual(source);
+  });
+
+  it('Change the name order and get its source (western)', () => {
+    const name = new Name({
+      name: {
+        given: 'John',
+        middle: 'Middle',
+        family: 'Doe'
+      },
+      order: ['given', 'middle', 'family'],
+      encode: 'western'
+    });
+    const source = {
+      encode: 'western',
+      name: {
+        family: 'Doe',
+        given: 'John',
+        middle: 'Middle'
+      },
+      order: ['given', 'middle', 'family']
+    };
+
+    name.setOrder(WESTERN_ORDER);
+    expect(name.source()).toEqual(source);
+  });
+
+  it('Print western name as other name orders', () => {
+    const name = new Name({
+      name: {
+        given: 'John',
+        middle: 'Middle',
+        family: 'Doe'
+      },
+      order: ['given', 'middle', 'family'],
+      encode: 'western'
+    });
+
+    expect(name.formattedName()).toBe('John Middle Doe');
+    expect(name.formattedName('lexical')).toBe('Doe, John');
+    expect(name.formattedName('eastern')).toBe('Doe John');
+  });
+
+  it('Print the name as a capitalized family name', () => {
+    const name = new Name({
+      name: {
+        given: 'John',
+        middle: 'Middle',
+        family: 'Doe'
+      },
+      order: ['given', 'middle', 'family'],
+      encode: 'western'
+    });
+
+    expect(name.capitalFamilyName().formattedName()).toBe('John Middle DOE');
+  });
+
+  it('Print the name as a simplified middle name', () => {
+    const name = new Name({
+      name: {
+        given: 'John',
+        middle: 'Middle',
+        family: 'Doe'
+      },
+      order: ['given', 'middle', 'family'],
+      encode: 'western'
+    });
+
+    expect(name.initialMiddleName().formattedName()).toBe('John M. Doe');
+  });
+
+  it('Add honorifics with simplified given name', () => {
+    const name = new Name({
+      name: {
+        given: 'John',
+        middle: 'Middle',
+        family: 'Doe'
+      },
+      order: ['given', 'middle', 'family'],
+      encode: 'western'
+    });
+
+    expect(name.initialGivenName().prefix('Dr.').fullName()).toBe('Dr. J. Doe');
+    expect(name.initialGivenName(true).fullName()).toBe('J. Middle Doe');
+  });
+});
+
+describe('Migrate to the model from a pure string', () => {
+  it('Migrate name to eastern model', () => {
+    const targetName = '홍길동';
+    const model = {
+      encode: 'eastern',
+      name: {
+        family: '홍',
+        given: '길동'
+      },
+      order: ['family', 'given']
+    };
+
+    expect(easternToName(targetName)).toEqual(model);
+  });
+
+  it('Migrate name to mononym model', () => {
+    const targetName = 'k4ng';
+    const model = {
+      encode: 'mononym',
+      name: 'k4ng',
+      order: []
+    };
+
+    expect(mononymToName(targetName)).toEqual(model);
+  });
+
+  it('Migrate name to western model', () => {
+    const targetName = 'John Middle Doe';
+    const model = {
+      encode: 'western',
+      name: {
+        family: 'Doe',
+        given: 'John',
+        middle: 'Middle'
+      },
+      order: ['given', 'middle', 'family']
+    };
+
+    expect(westernToName(targetName)).toEqual(model);
   });
 });

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,1 @@
+export { EASTERN_ORDER, WESTERN_ORDER } from './orders';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,1 +1,2 @@
 export { EASTERN_ORDER, WESTERN_ORDER } from './orders';
+export { PLACEHOLDERS } from './placeholders';

--- a/src/constants/orders.ts
+++ b/src/constants/orders.ts
@@ -1,0 +1,2 @@
+export const EASTERN_ORDER = ['family', 'given'];
+export const WESTERN_ORDER = ['given', 'middle', 'family'];

--- a/src/constants/placeholders.ts
+++ b/src/constants/placeholders.ts
@@ -1,0 +1,7 @@
+export const PLACEHOLDERS = {
+  family: 'family',
+  given: 'given',
+  middle: 'middle',
+  prefix: 'prefix',
+  suffix: 'suffix'
+} as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export default function add(a: number, b: number) {
-  return a + b;
-}
+export { Name } from './models';
+export { EASTERN_ORDER, WESTERN_ORDER } from './constants';
+export { easternToName, mononymToName, westernToName } from './utils';

--- a/src/models/Name.ts
+++ b/src/models/Name.ts
@@ -13,14 +13,14 @@ interface Source {
 }
 
 export default class Name {
-  private _name: NameType;
-  private _order: OrderType = [];
-  private _encode: EncodeType = 'western';
+  private name: NameType;
+  private order: OrderType = [];
+  private encode: EncodeType = 'western';
 
   constructor(source: Source) {
-    this._name = source.name;
-    this._order = source.order;
-    this._encode = source.encode;
+    this.name = source.name;
+    this.order = source.order;
+    this.encode = source.encode;
   }
 
   public static isValidName(name: NameType) {
@@ -48,7 +48,15 @@ export default class Name {
     return order.every(o => PLACEHOLDERS[o]);
   }
 
-  public name(order?: string) {
+  public source() {
+    return {
+      name: this.getName(),
+      order: this.getOrder(),
+      encode: this.getEncode()
+    };
+  }
+
+  public formattedName(order?: string) {
     if (typeof this.getName() === 'string') {
       return this.getName();
     }
@@ -62,18 +70,18 @@ export default class Name {
       const clone = cloneDeep(this);
       clone.setOrder(EASTERN_ORDER);
 
-      return clone.name();
+      return clone.formattedName();
     } else if (order === 'lexical') {
       return [this.getName('family'), ', ', this.getName('given')].join('');
     } else if (order === 'western' || order === 'given-first') {
       const clone = cloneDeep(this);
       clone.setOrder(WESTERN_ORDER);
 
-      return clone.name();
+      return clone.formattedName();
     }
 
     orders.forEach(order => {
-      if (this._name[order] && this.getName(order)) {
+      if (this.name[order] && this.getName(order)) {
         orderedNames.push(this.getName(order));
       }
     });
@@ -87,57 +95,61 @@ export default class Name {
     const prefix = this.getName('prefix');
     const suffix = this.getName('suffix');
 
-    return `${prefix + prefix ? ' ' : ''}${this.name()}${' ' + suffix || ''}`;
+    return `${prefix ? prefix + ' ' : ''}${this.formattedName()}${
+      suffix ? ' ' + suffix : ''
+    }`;
   }
 
   public getName(placeholder?: string) {
     if (placeholder) {
-      return this._name[placeholder];
+      return this.name[placeholder];
     }
 
-    return this._name;
+    return this.name;
   }
 
-  private setName(name: string, placeholder?: string) {
+  public setName(name: string, placeholder?: string) {
     if (this.isMononym()) {
       return;
     }
 
     if (!Name.isValidName(name)) {
-      return false;
+      throw new Error('Error occured');
     }
 
     if (placeholder) {
-      this._name[placeholder] = name;
+      this.name[placeholder] = name;
+    } else {
+      this.name = name;
     }
   }
 
   public getOrder() {
-    return this._order;
+    return this.order;
   }
 
-  private setOrder(order: OrderType) {
+  public setOrder(order: OrderType) {
     if (this.isMononym()) {
       return;
     }
 
     if (!Name.isValidOrder(order)) {
-      return false;
+      throw new Error('Error occured');
     }
 
-    this._order = order;
+    this.order = order;
   }
 
   public getEncode() {
-    return this._encode;
+    return this.encode;
   }
 
-  private setEncode(encode: EncodeType) {
+  public setEncode(encode: EncodeType) {
     if (this.isMononym()) {
       return;
     }
 
-    this._encode = encode;
+    this.encode = encode;
   }
 
   public capitalFamilyName() {
@@ -164,6 +176,7 @@ export default class Name {
       const middleRemovedOrder = clone
         .getOrder()
         .filter(order => order !== 'middle');
+
       clone.setOrder(middleRemovedOrder);
     }
 

--- a/src/models/Name.ts
+++ b/src/models/Name.ts
@@ -23,7 +23,7 @@ export default class Name {
     this.encode = source.encode;
   }
 
-  public static isValidName(name: NameType) {
+  public static isNameValid(name: NameType) {
     // Use toString method for clearer type checking.
     if (name?.toString() === '[object Object]') {
       const placholders = Object.keys(name);
@@ -40,7 +40,7 @@ export default class Name {
     return true;
   }
 
-  public static isValidOrder(order: OrderType) {
+  public static isOrderValid(order: OrderType) {
     if (!Array.isArray(order)) {
       return false;
     }
@@ -113,7 +113,7 @@ export default class Name {
       return;
     }
 
-    if (!Name.isValidName(name)) {
+    if (!Name.isNameValid(name)) {
       throw new Error('Error occured');
     }
 
@@ -122,6 +122,8 @@ export default class Name {
     } else {
       this.name = name;
     }
+
+    return this;
   }
 
   public getOrder() {
@@ -133,11 +135,13 @@ export default class Name {
       return;
     }
 
-    if (!Name.isValidOrder(order)) {
+    if (!Name.isOrderValid(order)) {
       throw new Error('Error occured');
     }
 
     this.order = order;
+
+    return this;
   }
 
   public getEncode() {
@@ -150,6 +154,8 @@ export default class Name {
     }
 
     this.encode = encode;
+
+    return this;
   }
 
   public capitalFamilyName() {
@@ -163,7 +169,7 @@ export default class Name {
     return clone;
   }
 
-  public initialGivenName(isIncludingMiddle?: boolean) {
+  public initialGivenName(includeMiddle?: boolean) {
     if (this.isMononym() || this.getEncode() === 'eastern') {
       return this;
     }
@@ -172,7 +178,7 @@ export default class Name {
     const initializedName = `${clone.getName('given')[0]}.`;
     clone.setName(initializedName, 'given');
 
-    if (!isIncludingMiddle && this.getName('middle')) {
+    if (!includeMiddle && this.getName('middle')) {
       const middleRemovedOrder = clone
         .getOrder()
         .filter(order => order !== 'middle');

--- a/src/models/Name.ts
+++ b/src/models/Name.ts
@@ -1,0 +1,210 @@
+import cloneDeep from 'lodash.clonedeep';
+
+import { EASTERN_ORDER, WESTERN_ORDER, PLACEHOLDERS } from '../constants';
+
+type NameType = string | Record<string, unknown>;
+type OrderType = string[];
+type EncodeType = string;
+
+interface Source {
+  name: NameType;
+  order: OrderType;
+  encode: EncodeType;
+}
+
+export default class Name {
+  private _name: NameType;
+  private _order: OrderType = [];
+  private _encode: EncodeType = 'western';
+
+  constructor(source: Source) {
+    this._name = source.name;
+    this._order = source.order;
+    this._encode = source.encode;
+  }
+
+  public static isValidName(name: NameType) {
+    // Use toString method for clearer type checking.
+    if (name?.toString() === '[object Object]') {
+      const placholders = Object.keys(name);
+
+      if (!placholders.length) {
+        return false;
+      }
+
+      return placholders.every(p => PLACEHOLDERS[p]);
+    } else if (typeof name === 'string') {
+      return !!name;
+    }
+
+    return true;
+  }
+
+  public static isValidOrder(order: OrderType) {
+    if (!Array.isArray(order)) {
+      return false;
+    }
+
+    return order.every(o => PLACEHOLDERS[o]);
+  }
+
+  public name(order?: string) {
+    if (typeof this.getName() === 'string') {
+      return this.getName();
+    }
+
+    const orderedNames = [];
+    let orders;
+
+    if (!order) {
+      orders = this.getOrder();
+    } else if (order === 'eastern' || order === 'family-first') {
+      const clone = cloneDeep(this);
+      clone.setOrder(EASTERN_ORDER);
+
+      return clone.name();
+    } else if (order === 'lexical') {
+      return [this.getName('family'), ', ', this.getName('given')].join('');
+    } else if (order === 'western' || order === 'given-first') {
+      const clone = cloneDeep(this);
+      clone.setOrder(WESTERN_ORDER);
+
+      return clone.name();
+    }
+
+    orders.forEach(order => {
+      if (this._name[order] && this.getName(order)) {
+        orderedNames.push(this.getName(order));
+      }
+    });
+
+    const space = this.getSpace();
+
+    return orderedNames.join(space);
+  }
+
+  public fullName() {
+    const prefix = this.getName('prefix');
+    const suffix = this.getName('suffix');
+
+    return `${prefix + prefix ? ' ' : ''}${this.name()}${' ' + suffix || ''}`;
+  }
+
+  public getName(placeholder?: string) {
+    if (placeholder) {
+      return this._name[placeholder];
+    }
+
+    return this._name;
+  }
+
+  private setName(name: string, placeholder?: string) {
+    if (this.isMononym()) {
+      return;
+    }
+
+    if (!Name.isValidName(name)) {
+      return false;
+    }
+
+    if (placeholder) {
+      this._name[placeholder] = name;
+    }
+  }
+
+  public getOrder() {
+    return this._order;
+  }
+
+  private setOrder(order: OrderType) {
+    if (this.isMononym()) {
+      return;
+    }
+
+    if (!Name.isValidOrder(order)) {
+      return false;
+    }
+
+    this._order = order;
+  }
+
+  public getEncode() {
+    return this._encode;
+  }
+
+  private setEncode(encode: EncodeType) {
+    if (this.isMononym()) {
+      return;
+    }
+
+    this._encode = encode;
+  }
+
+  public capitalFamilyName() {
+    if (this.isMononym() || this.getEncode() === 'eastern') {
+      return this;
+    }
+
+    const clone = cloneDeep(this);
+    clone.setName(clone.getName('family').toUpperCase(), 'family');
+
+    return clone;
+  }
+
+  public initialGivenName(isIncludingMiddle?: boolean) {
+    if (this.isMononym() || this.getEncode() === 'eastern') {
+      return this;
+    }
+
+    const clone = cloneDeep(this);
+    const initializedName = `${clone.getName('given')[0]}.`;
+    clone.setName(initializedName, 'given');
+
+    if (!isIncludingMiddle && this.getName('middle')) {
+      const middleRemovedOrder = clone
+        .getOrder()
+        .filter(order => order !== 'middle');
+      clone.setOrder(middleRemovedOrder);
+    }
+
+    return clone;
+  }
+
+  public initialMiddleName() {
+    if (
+      this.isMononym() ||
+      this.getEncode() === 'eastern' ||
+      !this.getName('middle')
+    ) {
+      return this;
+    }
+
+    const clone = cloneDeep(this);
+    const initializedName = `${clone.getName('middle')[0]}.`;
+    clone.setName(initializedName, 'middle');
+
+    return clone;
+  }
+
+  public prefix(customPrefix: string) {
+    const clone = cloneDeep(this);
+    clone.setName(customPrefix, 'prefix');
+
+    return clone;
+  }
+
+  public suffix(customSuffix: string) {
+    const clone = cloneDeep(this);
+    clone.setName(customSuffix, 'suffix');
+
+    return clone;
+  }
+
+  private isMononym() {
+    return typeof this.getName() === 'string' && !this.getOrder().length;
+  }
+
+  private getSpace() {
+    return this.getEncode() === 'western' ? ' ' : '';
+  }
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,0 +1,1 @@
+export { default as Name } from './Name';

--- a/src/utils/converter.ts
+++ b/src/utils/converter.ts
@@ -1,0 +1,51 @@
+import { Name } from '../models';
+import { EASTERN_ORDER, WESTERN_ORDER } from '../constants';
+
+export const easternToName = (name: string) => {
+  const nameLeng = name.length;
+  const filteredName =
+    nameLeng > 2
+      ? {
+          family: name.slice(0, -2),
+          given: name.slice(-2, nameLeng)
+        }
+      : {
+          family: name[0],
+          given: name[1]
+        };
+
+  return new Name({
+    name: filteredName,
+    order: EASTERN_ORDER,
+    encode: 'eastern'
+  });
+};
+
+export const mononymToName = (name: string) => {
+  return new Name({
+    name,
+    order: [],
+    encode: 'mononym'
+  });
+};
+
+export const westernToName = (name: string) => {
+  const splittedName = name.split(' ');
+  const filteredName =
+    splittedName.length === 2
+      ? {
+          given: splittedName[0],
+          family: splittedName[1]
+        }
+      : {
+          given: splittedName[0],
+          middle: splittedName[1],
+          family: splittedName[2]
+        };
+
+  return new Name({
+    name: filteredName,
+    order: WESTERN_ORDER,
+    encode: 'western'
+  });
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export { easternToName, mononymToName, westernToName } from './converter';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1235,6 +1235,18 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/lodash.clonedeep@^4.5.6":
+  version "4.5.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz#3b6c40a0affe0799a2ce823b440a6cf33571d32b"
+  integrity sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.168"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
+  integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
+
 "@types/node@*":
   version "14.14.37"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.37.tgz#a3dd8da4eb84a996c36e331df98d82abd76b516e"


### PR DESCRIPTION
### Operation
I migrated python code(**py-universal-name-format**) to typescript with test code.
The reason why the coverage of the test code is not 100% is that there is no test-case for the overall function within the 'Name' model.
But, I think it does not matter :D

### Coverage
<img src="https://user-images.githubusercontent.com/23455736/113482290-f473ab00-94d8-11eb-9c25-e71e847b7b7c.png" width="500">

---

<img src="https://user-images.githubusercontent.com/23455736/113482265-caba8400-94d8-11eb-8d42-be07cdceb1b1.png" width="750">

